### PR TITLE
feat: MGS-5450 remove generated from clean method

### DIFF
--- a/rootfs/usr/bin/mgs-run-tests
+++ b/rootfs/usr/bin/mgs-run-tests
@@ -63,7 +63,6 @@ ENDSQL
 
 function clean() {
     rm -rf \
-        /var/www/html/generated/* \
         /var/www/html/var/* \
         /var/www/html/dev/tests/integration/tmp/*
 }


### PR DESCRIPTION
Remove clearing `generated` folder as it is not used in integration tests.